### PR TITLE
hid_osx: Use CFRunLoopGetCurrent

### DIFF
--- a/src/hid_osx.c
+++ b/src/hid_osx.c
@@ -328,7 +328,7 @@ removal_callback(void *context, IOReturn result, void *sender)
 	(void)result;
 	(void)sender;
 
-	CFRunLoopStop(CFRunLoopGetMain());
+	CFRunLoopStop(CFRunLoopGetCurrent());
 }
 
 static int
@@ -440,7 +440,7 @@ fido_hid_open(const char *path)
 	IOHIDDeviceRegisterInputReportCallback(ctx->ref, ctx->report,
 	    (long)ctx->report_in_len, &report_callback, ctx);
 	IOHIDDeviceRegisterRemovalCallback(ctx->ref, &removal_callback, ctx);
-	IOHIDDeviceScheduleWithRunLoop(ctx->ref, CFRunLoopGetMain(),
+	IOHIDDeviceScheduleWithRunLoop(ctx->ref, CFRunLoopGetCurrent(),
 	    ctx->loop_id);
 
 	ok = 0;
@@ -472,7 +472,7 @@ fido_hid_close(void *handle)
 	IOHIDDeviceRegisterInputReportCallback(ctx->ref, ctx->report,
 	    (long)ctx->report_in_len, NULL, ctx);
 	IOHIDDeviceRegisterRemovalCallback(ctx->ref, NULL, NULL);
-	IOHIDDeviceUnscheduleFromRunLoop(ctx->ref, CFRunLoopGetMain(),
+	IOHIDDeviceUnscheduleFromRunLoop(ctx->ref, CFRunLoopGetCurrent(),
 	    ctx->loop_id);
 
 	if (IOHIDDeviceClose(ctx->ref,


### PR DESCRIPTION
I was having trouble using the latest libfido2 library with go-libfido2. I was getting an FIDO_ERR_RX on fido_dev_open (though only on the second or subsequent opens).

I tracked it down the failures starting happening after this commit: 2d0a839

It seems like the change to use CFRunLoopGetMain instead of CFRunLoopGetCurrent breaks the usage of the library under cgo.

I'm still investigating the use of RunLoops with IOHIDDeviceScheduleWithRunLoop and what the right thing to do is, but I thought I would submit this in case anyone else was encountering issues. Also I don't know if this is an issue with go/cgo either.